### PR TITLE
Make usage stats opt-in

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,9 +46,16 @@ If that doesn't work try `py -m pip install dicebear`
 ## Usage  
 Important note: *Pillow* is not a required dependency, it's only required when you want to be able to edit the avatar images (using `DAvatar.pillow()`).
 When using a `PIL` function while it's not installed it will raise `dicebear.errors.PILError`.  
+
+When the environment variable `ENABLE_PYTHON_DICEBEAR_USAGE_STATS` is set, an API will be pinged on most function calls to update this package's usage stats. This will be used to analyse Dicebear's usage and improve your overall experience, but may have performance costs.
 ```py  
 import PIL.Image
 from dicebear import DAvatar, DStyle, DOptions, DColor, DFormat, bulk_create
+import os
+
+
+# Enable usage statistics
+os.environ['ENABLE_PYTHON_DICEBEAR_USAGE_STATS'] = 'true'
 
 
 # Creating options

--- a/dicebear/models.py
+++ b/dicebear/models.py
@@ -23,6 +23,7 @@
 from typing import Union, List
 from random import choice, choices
 from requests import post, get
+from os import environ
 
 from .errors import *
 
@@ -243,6 +244,8 @@ def _statsIncrease(_file: str, _class: str, _function: str, *, _test: bool = Fal
     """
     Pings an API to update this package's usage stats. This will be used to analyse Dicebear's usage and improve your overall experience.
     """
+    if environ.get('ENABLE_PYTHON_DICEBEAR_USAGE_STATS', '').lower() != 'true':
+        return
     __body = {"file": _file, "class": _class, "function": _function, "test": str(_test).lower()}
     __headers = {"User-Agent": "pipedream/1", "Content-Type": "application/json", "-Key": "acbd2023"}
     post("https://eo1p6rm1ydzj8yl.m.pipedream.net/runs", json=__body, headers=__headers, timeout=10)

--- a/examples/dicebear.py
+++ b/examples/dicebear.py
@@ -1,5 +1,10 @@
 import PIL.Image
 from dicebear import DAvatar, DStyle, DOptions, DColor, DFormat, bulk_create
+import os
+
+
+# Enable usage statistics
+os.environ['ENABLE_PYTHON_DICEBEAR_USAGE_STATS'] = 'true'
 
 
 # Creating options


### PR DESCRIPTION
The package currently pings an API on almost every function call to record package usage stats, with no way to opt-out. This is not clearly mentioned in the documentation except a line in the changelog from when it was added. The user should be actively aware of when this is happening.

Forced usage stats are bad for performance and are a significant security/privacy concern. The changelog says no personal data is stored, but it's not possible for the user to completely verify this (the server could be logging their IP for all they know).

This PR makes the reporting of usage stats opt-in by requiring the user to explicitly consent to this by setting the environment variable `ENABLE_PYTHON_DICEBEAR_USAGE_STATS` to `true`, otherwise usage stats won't be sent. This is consistent with modern software which requires informed explicit consent from the user before usage stats are sent, even when they are anonymised.

README and example have been updated to mention this setting.